### PR TITLE
feat: 와인 등록 기능 비활성화 (포트폴리오 아이템 유지)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,13 +71,13 @@ export default function RootLayout({
         <QueryProvider>
           <UserProvider>
             <ToastProvider>
-              <ModalProvider>
-                <DialogProvider>
+              <DialogProvider>
+                <ModalProvider>
                   <Header />
                   <main className="flex-1">{children}</main>
                   <Footer />
-                </DialogProvider>
-              </ModalProvider>
+                </ModalProvider>
+              </DialogProvider>
             </ToastProvider>
           </UserProvider>
         </QueryProvider>

--- a/src/app/wines/_components/register/WineRegisterForm.tsx
+++ b/src/app/wines/_components/register/WineRegisterForm.tsx
@@ -12,6 +12,7 @@ import TextInput from "./TextInput";
 import WineTypeSelector from "./WineTypeSelector";
 import { getImageURL, postWine } from "@/libs/api/wines/getAPIData";
 import { useToast } from "@/components/ToastProvider";
+import { useDialog } from "@/components/DialogProvider";
 
 export interface PostWineValue {
   name: string;
@@ -28,6 +29,7 @@ interface WineRegisterFormProps {
 export default function WineRegisterForm({ onSuccess }: WineRegisterFormProps) {
   const { onClose } = useModal();
   const { showToast } = useToast();
+  const { showAlert } = useDialog();
 
   const onSubmit = async (
     values: WineRegisterFormValues,
@@ -82,11 +84,16 @@ export default function WineRegisterForm({ onSuccess }: WineRegisterFormProps) {
           <TextInput label="원산지" name="region" placeholder="원산지 입력" />
 
           <button
-            type="submit"
-            disabled={isSubmitting}
+            type="button"
+            onClick={() =>
+              showAlert(
+                "현재 포트폴리오 아이템 유지를 위해 와인 등록 기능이 비활성화되어 있습니다.\n리뷰 등록은 정상적으로 이용 가능합니다.",
+                { title: "안내" },
+              )
+            }
             className={cn(
               "mt-4 w-full cursor-pointer rounded-sm bg-black py-3.5 text-sm font-bold text-white",
-              "hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50",
+              "hover:bg-primary/90",
             )}
           >
             와인 등록하기

--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -15,6 +15,7 @@ interface ConfirmData {
   confirmText?: string;
   cancelText?: string;
   onConfirm: () => void;
+  alertOnly?: boolean;
 }
 
 interface DialogContextValue {
@@ -22,6 +23,10 @@ interface DialogContextValue {
     message: string,
     onConfirm: () => void,
     options?: { title?: string; confirmText?: string; cancelText?: string },
+  ) => void;
+  showAlert: (
+    message: string,
+    options?: { title?: string; confirmText?: string },
   ) => void;
 }
 
@@ -37,6 +42,16 @@ export function DialogProvider({ children }: { children: ReactNode }) {
       options?: { title?: string; confirmText?: string; cancelText?: string },
     ) => {
       setDialog({ message, onConfirm, ...options });
+    },
+    [],
+  );
+
+  const showAlert = useCallback(
+    (
+      message: string,
+      options?: { title?: string; confirmText?: string },
+    ) => {
+      setDialog({ message, onConfirm: () => {}, alertOnly: true, ...options });
     },
     [],
   );
@@ -67,7 +82,7 @@ export function DialogProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <DialogContext.Provider value={{ showConfirm }}>
+    <DialogContext.Provider value={{ showConfirm, showAlert }}>
       {children}
       {dialog && (
         <div
@@ -86,15 +101,17 @@ export function DialogProvider({ children }: { children: ReactNode }) {
               {dialog.message}
             </p>
             <div className="flex justify-end gap-3">
-              <Button variant="outline" size="md" onClick={onClose}>
-                {dialog.cancelText ?? "취소"}
-              </Button>
+              {!dialog.alertOnly && (
+                <Button variant="outline" size="md" onClick={onClose}>
+                  {dialog.cancelText ?? "취소"}
+                </Button>
+              )}
               <Button
                 size="md"
-                className="bg-error hover:bg-error/90"
+                className={dialog.alertOnly ? "" : "bg-error hover:bg-error/90"}
                 onClick={handleConfirm}
               >
-                {dialog.confirmText ?? "삭제"}
+                {dialog.confirmText ?? (dialog.alertOnly ? "확인" : "삭제")}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- `WineRegisterForm` 등록 버튼 클릭 시 `window.alert` 대신 커스텀 다이얼로그로 안내
- `DialogProvider`에 `showAlert` 추가 — 확인 버튼만 있는 단일 버튼 모달
- `layout.tsx` provider 순서 변경: `DialogProvider`가 `ModalProvider`를 감싸도록 수정 (모달 내부 컴포넌트에서 `DialogContext` 접근 가능)

## Test plan

- [ ] 와인 등록 폼 정상 오픈 확인
- [ ] "와인 등록하기" 버튼 클릭 시 커스텀 안내 모달 표시
- [ ] 안내 모달 "확인" 버튼으로 닫기
- [ ] 기존 삭제 확인 다이얼로그 정상 동작 확인 (리뷰/와인 삭제)

🤖 Generated with [Claude Code](https://claude.com/claude-code)