### PR TITLE
refactor: Modal/Dialog 접근성 강화 — inert, createPortal, 포커스 관리

### DIFF
--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -4,10 +4,11 @@ import {
   useContext,
   useState,
   useCallback,
-  useEffect,
   ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/Button";
+import { useFocusTrap } from "@/libs/hooks/useFocusTrap";
 
 interface ConfirmData {
   message: string;
@@ -35,88 +36,80 @@ const DialogContext = createContext<DialogContextValue | null>(null);
 export function DialogProvider({ children }: { children: ReactNode }) {
   const [dialog, setDialog] = useState<ConfirmData | null>(null);
 
+  const onClose = useCallback(() => setDialog(null), []);
+
+  const { panelRef, saveTrigger } = useFocusTrap(dialog !== null, onClose);
+
   const showConfirm = useCallback(
     (
       message: string,
       onConfirm: () => void,
       options?: { title?: string; confirmText?: string; cancelText?: string },
     ) => {
+      saveTrigger();
       setDialog({ message, onConfirm, ...options });
     },
-    [],
+    [saveTrigger],
   );
 
   const showAlert = useCallback(
-    (
-      message: string,
-      options?: { title?: string; confirmText?: string },
-    ) => {
+    (message: string, options?: { title?: string; confirmText?: string }) => {
+      saveTrigger();
       setDialog({ message, onConfirm: () => {}, alertOnly: true, ...options });
     },
-    [],
+    [saveTrigger],
   );
 
-  const onClose = useCallback(() => {
-    setDialog(null);
-  }, []);
-
-  useEffect(() => {
-    if (!dialog) return;
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKeyDown);
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = "";
-    };
-  }, [dialog, onClose]);
-
-  const handleConfirm = () => {
+  const handleConfirm = useCallback(() => {
     const cb = dialog?.onConfirm;
     onClose();
     cb?.();
-  };
+  }, [dialog, onClose]);
 
   return (
     <DialogContext.Provider value={{ showConfirm, showAlert }}>
-      {children}
-      {dialog && (
-        <div
-          role="alertdialog"
-          aria-modal="true"
-          aria-labelledby="dialog-title"
-          aria-describedby="dialog-message"
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
-          onClick={(e) => e.target === e.currentTarget && onClose()}
-        >
-          <div className="w-[320px] rounded-sm bg-white px-8 py-8">
-            <h2 id="dialog-title" className="mb-3 text-xl font-bold">
-              {dialog.title ?? "삭제 확인"}
-            </h2>
-            <p id="dialog-message" className="mb-8 text-sm text-gray-600">
-              {dialog.message}
-            </p>
-            <div className="flex justify-end gap-3">
-              {!dialog.alertOnly && (
-                <Button variant="outline" size="md" onClick={onClose}>
-                  {dialog.cancelText ?? "취소"}
+      <div className="contents" inert={dialog !== null}>
+        {children}
+      </div>
+      {dialog &&
+        createPortal(
+          <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="dialog-title"
+            aria-describedby="dialog-message"
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
+            onClick={(e) => e.target === e.currentTarget && onClose()}
+          >
+            <div
+              ref={panelRef}
+              tabIndex={-1}
+              className="w-[320px] rounded-sm bg-white px-8 py-8"
+            >
+              <h2 id="dialog-title" className="mb-3 text-xl font-bold">
+                {dialog.title ?? "삭제 확인"}
+              </h2>
+              <p id="dialog-message" className="mb-8 text-sm text-gray-600">
+                {dialog.message}
+              </p>
+              <div className="flex justify-end gap-3">
+                {!dialog.alertOnly && (
+                  <Button variant="outline" size="md" onClick={onClose}>
+                    {dialog.cancelText ?? "취소"}
+                  </Button>
+                )}
+                <Button
+                  size="md"
+                  className={dialog.alertOnly ? "" : "bg-error hover:bg-error/90"}
+                  onClick={handleConfirm}
+                >
+                  {dialog.confirmText ?? (dialog.alertOnly ? "확인" : "삭제")}
                 </Button>
-              )}
-              <Button
-                size="md"
-                className={dialog.alertOnly ? "" : "bg-error hover:bg-error/90"}
-                onClick={handleConfirm}
-              >
-                {dialog.confirmText ?? (dialog.alertOnly ? "확인" : "삭제")}
-              </Button>
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body,
+        )}
     </DialogContext.Provider>
   );
 }

--- a/src/components/ModalProvider.tsx
+++ b/src/components/ModalProvider.tsx
@@ -5,8 +5,9 @@ import {
   useState,
   useCallback,
   ReactNode,
-  useEffect,
 } from "react";
+import { createPortal } from "react-dom";
+import { useFocusTrap } from "@/libs/hooks/useFocusTrap";
 
 interface ModalData {
   content: ReactNode;
@@ -27,60 +28,54 @@ interface ModalProviderProps {
 export function ModalProvider({ children }: ModalProviderProps) {
   const [modal, setModal] = useState<ModalData | null>(null);
 
-  const showModal = useCallback((content: ReactNode, title: string) => {
-    setModal({ content, title });
-  }, []);
+  const onClose = useCallback(() => setModal(null), []);
 
-  const onClose = useCallback(() => {
-    setModal(null);
-  }, []);
+  const { panelRef, saveTrigger } = useFocusTrap(modal !== null, onClose);
 
-  useEffect(() => {
-    if (!modal) return;
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKeyDown);
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = "";
-    };
-  }, [onClose, modal]);
+  const showModal = useCallback(
+    (content: ReactNode, title: string) => {
+      saveTrigger();
+      setModal({ content, title });
+    },
+    [saveTrigger],
+  );
 
   return (
     <ModalContext.Provider value={{ showModal, onClose }}>
-      {children}
-      {modal && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="modal-title"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={(e) => e.target === e.currentTarget && onClose()}
-        >
+      <div className="contents" inert={modal !== null}>
+        {children}
+      </div>
+      {modal &&
+        createPortal(
           <div
-            className="scrollbar-ghost relative w-full max-w-[550px] max-h-[85vh] overflow-y-auto rounded-sm bg-white py-8 pr-6 pl-7"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="modal-title"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+            onClick={(e) => e.target === e.currentTarget && onClose()}
           >
-            <div className="mb-6 flex items-center justify-between">
-              <h2 id="modal-title" className="text-xl font-bold">
-                {modal.title}
-              </h2>
-              <button
-                onClick={onClose}
-                aria-label="닫기"
-                className="cursor-pointer text-2xl text-gray-600 hover:text-black"
-              >
-                ✕
-              </button>
+            <div
+              ref={panelRef}
+              tabIndex={-1}
+              className="scrollbar-ghost relative w-full max-w-[550px] max-h-[85vh] overflow-y-auto rounded-sm bg-white py-8 pr-6 pl-7"
+            >
+              <div className="mb-6 flex items-center justify-between">
+                <h2 id="modal-title" className="text-xl font-bold">
+                  {modal.title}
+                </h2>
+                <button
+                  onClick={onClose}
+                  aria-label="닫기"
+                  className="cursor-pointer text-2xl text-gray-600 hover:text-black"
+                >
+                  ✕
+                </button>
+              </div>
+              {modal.content}
             </div>
-
-            {modal.content}
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body,
+        )}
     </ModalContext.Provider>
   );
 }

--- a/src/libs/hooks/useFocusTrap.ts
+++ b/src/libs/hooks/useFocusTrap.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTORS =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+export function useFocusTrap(isOpen: boolean, onClose: () => void) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+
+  const saveTrigger = useCallback(() => {
+    triggerRef.current = document.activeElement;
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const focusable = panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+    (focusable?.[0] ?? panelRef.current)?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const nodes = panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+      if (!nodes?.length) return;
+
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      (triggerRef.current as HTMLElement | null)?.focus();
+    };
+  }, [isOpen, onClose]);
+
+  return { panelRef, saveTrigger };
+}


### PR DESCRIPTION
## Summary

- `createPortal`로 `document.body`에 직접 렌더링 — z-index stacking context 이슈 제거
- 오버레이 open 시 children 래퍼에 `inert` 적용 — 키보드/포인터/스크린리더 배경 접근 완전 차단
- `useFocusTrap` 공통 훅 추출 (`src/libs/hooks/useFocusTrap.ts`) — Modal/Dialog 중복 30줄 제거
  - 포커스 트랩 (Tab/Shift+Tab 내부 순환)
  - open 시 첫 focusable 요소 자동 포커스
  - close 시 트리거 요소로 포커스 복원
  - `overflow` 이전 값 저장/복원 (동시 open 시 버그 수정)
- `showModal` 시그니처에서 `width`/`height` 제거, 호출부 정리 포함
- `ReviewList`의 `useUser() || null` dead code 수정

## Test plan

- [ ] 모달 open → Tab으로 배경 포커스 이동 불가 확인
- [ ] 모달 open → Shift+Tab 역방향 순환 확인
- [ ] 모달 close → 트리거 버튼으로 포커스 복귀 확인
- [ ] Escape로 모달/다이얼로그 닫힘 확인
- [ ] 다이얼로그와 모달 동시 open 시 scroll 상태 정상 확인
- [ ] 스크린리더(VoiceOver/NVDA)에서 배경 콘텐츠 읽기 차단 확인

closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)