### PR TITLE
fix: 모바일/태블릿 랜딩페이지 반응형 및 3D 렌더링 개선

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  reactCompiler: true,
+  reactCompiler: false,
   images: {
     remotePatterns: [
       {

--- a/src/app/_components/LandingInfo.tsx
+++ b/src/app/_components/LandingInfo.tsx
@@ -1,19 +1,19 @@
 "use client";
 
 import { motion, Variants, Easing } from "framer-motion";
-import { SCROLL_HEIGHT_VH } from "./LandingSection";
 
 interface LandingInfoProps {
   progress: number;
+  onScrollToEnd: () => void;
 }
 
-export default function LandingInfo({ progress }: LandingInfoProps) {
+export default function LandingInfo({ progress, onScrollToEnd }: LandingInfoProps) {
   const translateY = -progress * 150;
 
   return (
     <>
       <motion.div
-        className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center pb-20"
+        className="pointer-events-none absolute inset-x-0 bottom-0 top-[70px] z-10 flex flex-col items-center justify-center"
         variants={containerVariants}
         initial="hidden"
         animate="visible"
@@ -33,7 +33,7 @@ export default function LandingInfo({ progress }: LandingInfoProps) {
         </motion.p>
 
         <motion.h1
-          className="mt-12 flex text-7xl font-bold tracking-wider text-white md:mt-16 md:text-9xl"
+          className="mt-8 flex text-6xl font-bold tracking-wider text-white md:mt-16 md:text-9xl"
           variants={titleContainerVariants}
         >
           {"WINE 4 U".split("").map((char, i) => (
@@ -64,12 +64,7 @@ export default function LandingInfo({ progress }: LandingInfoProps) {
         className="pointer-events-auto absolute bottom-12 left-1/2 z-10 -translate-x-1/2 cursor-pointer text-7xl text-gray-300 transition-colors hover:text-white md:bottom-14 md:text-8xl"
         animate={{ y: [0, 10, 0] }}
         transition={{ duration: 1.5, repeat: Infinity }}
-        onClick={() => {
-          window.scrollTo({
-            top: window.innerHeight * (SCROLL_HEIGHT_VH / 100),
-            behavior: "smooth",
-          });
-        }}
+        onClick={onScrollToEnd}
       >
         ⌵
       </motion.button>
@@ -102,7 +97,6 @@ const titleContainerVariants: Variants = {
   visible: {
     transition: {
       staggerChildren: 0.08,
-      delayChildren: 0,
     },
   },
 };

--- a/src/app/_components/LandingSection.tsx
+++ b/src/app/_components/LandingSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useRef } from "react";
+import { ReactNode, useCallback, useRef } from "react";
 import LandingInfo from "./LandingInfo";
 import { RenderModel } from "./RenderModel";
 import { useScrollProgress } from "../_libs/useScrollProgress";
@@ -14,42 +14,50 @@ interface LandingSectionProps {
 }
 
 export const SCROLL_HEIGHT_VH = 280;
+const LANDING_BG = "#101318";
+const MOBILE_SCROLL_HEIGHT_VH = 101;
 
 export default function LandingSection({ children }: LandingSectionProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   useDeviceType();
   const { deviceType } = useDeviceTypeStore();
 
-  const scrollHeight = deviceType !== "mobile" ? SCROLL_HEIGHT_VH : 101;
+  const scrollHeight =
+    deviceType === "desktop" ? SCROLL_HEIGHT_VH : MOBILE_SCROLL_HEIGHT_VH;
 
   const { progress, isComplete } = useScrollProgress(
     containerRef,
     scrollHeight,
   );
 
+  const handleScrollToEnd = useCallback(() => {
+    window.scrollTo({
+      top: window.innerHeight * (SCROLL_HEIGHT_VH / 100),
+      behavior: "smooth",
+    });
+  }, []);
+
   return (
     <>
       <div
         ref={containerRef}
-        style={{ height: `${scrollHeight}vh` }}
+        style={{ height: `${scrollHeight}vh`, background: LANDING_BG }}
         className="relative"
       >
         <div
-          className="sticky top-0 h-screen w-full overflow-hidden pt-[70px]"
-          style={{
-            background: "#101318",
-          }}
+          className="sticky top-0 h-dvh w-full overflow-hidden"
+          style={{ background: LANDING_BG }}
         >
           <div className="absolute inset-0">
             <RenderModel deviceType={deviceType} progress={progress} />
           </div>
 
-          <LandingInfo progress={progress} />
+          <LandingInfo progress={progress} onScrollToEnd={handleScrollToEnd} />
         </div>
       </div>
 
       <div
-        className="transition-opacity duration-500"
+        className="overflow-x-hidden transition-opacity duration-500"
         style={{
           opacity: isComplete ? 1 : 0,
           pointerEvents: "none",
@@ -61,7 +69,7 @@ export default function LandingSection({ children }: LandingSectionProps) {
           href="/wines"
           className={cn(
             "hover:bg-primary/90 fixed bottom-28 left-1/2 h-12.5 w-71 -translate-x-1/2 cursor-pointer rounded-sm bg-black text-lg text-white",
-            isComplete ? "pointer-events-auto" : "pointer-none",
+            isComplete ? "pointer-events-auto" : "pointer-events-none",
             "flex items-center justify-center no-underline",
           )}
         >

--- a/src/app/_components/RenderModel.tsx
+++ b/src/app/_components/RenderModel.tsx
@@ -13,7 +13,7 @@ interface RenderModelProps {
 }
 
 export function RenderModel({ deviceType, progress }: RenderModelProps) {
-  if (deviceType === 'mobile') return null;
+  if (deviceType === 'mobile' || deviceType === 'tablet') return null;
 
   const opacity = progress > 0.85 ? 1 - (progress - 0.85) / 0.15 : 1;
 
@@ -23,7 +23,7 @@ export function RenderModel({ deviceType, progress }: RenderModelProps) {
         dpr={[1, 1.5]}
         gl={{ powerPreference: 'high-performance' }}
         camera={{ position: [0, 5, 14], fov: 55, near: 0.1, far: 200 }}
-        style={{ background: '#101318', touchAction: 'none' }}
+        style={{ background: '#101318', touchAction: 'pan-y' }}
       >
         <Suspense fallback={null}>
           <LightObject progress={progress} />

--- a/src/app/_libs/useScrollProgress.ts
+++ b/src/app/_libs/useScrollProgress.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 type ScrollHeight = number;
 
@@ -9,6 +9,7 @@ export function useScrollProgress(
   scrollHeight: ScrollHeight,
 ) {
   const [progress, setProgress] = useState(0);
+  const prevProgressRef = useRef(0);
 
   const handleScroll = useCallback(() => {
     const container = containerRef.current;
@@ -20,9 +21,13 @@ export function useScrollProgress(
       (scrollHeight / 100) * windowHeight - windowHeight;
     const scrolled = -rect.top;
     const rawProgress =
-      Math.round((scrolled / totalScrollDistance) * 1000) / 1000; //3째자리에서 반올림, 성능구려져서
+      Math.round((scrolled / totalScrollDistance) * 1000) / 1000;
 
-    setProgress(Math.max(0, Math.min(1, rawProgress)));
+    const next = Math.max(0, Math.min(1, rawProgress));
+    if (next === prevProgressRef.current) return;
+
+    prevProgressRef.current = next;
+    setProgress(next);
   }, [containerRef, scrollHeight]);
 
   useEffect(() => {

--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -4,10 +4,11 @@ import {
   useContext,
   useState,
   useCallback,
-  useEffect,
   ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/Button";
+import { useFocusTrap } from "@/libs/hooks/useFocusTrap";
 
 interface ConfirmData {
   message: string;
@@ -35,88 +36,80 @@ const DialogContext = createContext<DialogContextValue | null>(null);
 export function DialogProvider({ children }: { children: ReactNode }) {
   const [dialog, setDialog] = useState<ConfirmData | null>(null);
 
+  const onClose = useCallback(() => setDialog(null), []);
+
+  const { panelRef, saveTrigger } = useFocusTrap(dialog !== null, onClose);
+
   const showConfirm = useCallback(
     (
       message: string,
       onConfirm: () => void,
       options?: { title?: string; confirmText?: string; cancelText?: string },
     ) => {
+      saveTrigger();
       setDialog({ message, onConfirm, ...options });
     },
-    [],
+    [saveTrigger],
   );
 
   const showAlert = useCallback(
-    (
-      message: string,
-      options?: { title?: string; confirmText?: string },
-    ) => {
+    (message: string, options?: { title?: string; confirmText?: string }) => {
+      saveTrigger();
       setDialog({ message, onConfirm: () => {}, alertOnly: true, ...options });
     },
-    [],
+    [saveTrigger],
   );
 
-  const onClose = useCallback(() => {
-    setDialog(null);
-  }, []);
-
-  useEffect(() => {
-    if (!dialog) return;
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKeyDown);
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = "";
-    };
-  }, [dialog, onClose]);
-
-  const handleConfirm = () => {
+  const handleConfirm = useCallback(() => {
     const cb = dialog?.onConfirm;
     onClose();
     cb?.();
-  };
+  }, [dialog, onClose]);
 
   return (
     <DialogContext.Provider value={{ showConfirm, showAlert }}>
-      {children}
-      {dialog && (
-        <div
-          role="alertdialog"
-          aria-modal="true"
-          aria-labelledby="dialog-title"
-          aria-describedby="dialog-message"
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
-          onClick={(e) => e.target === e.currentTarget && onClose()}
-        >
-          <div className="w-[320px] rounded-sm bg-white px-8 py-8">
-            <h2 id="dialog-title" className="mb-3 text-xl font-bold">
-              {dialog.title ?? "삭제 확인"}
-            </h2>
-            <p id="dialog-message" className="mb-8 text-sm text-gray-600">
-              {dialog.message}
-            </p>
-            <div className="flex justify-end gap-3">
-              {!dialog.alertOnly && (
-                <Button variant="outline" size="md" onClick={onClose}>
-                  {dialog.cancelText ?? "취소"}
+      <div className="contents" inert={dialog !== null}>
+        {children}
+      </div>
+      {dialog &&
+        createPortal(
+          <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="dialog-title"
+            aria-describedby="dialog-message"
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
+            onClick={(e) => e.target === e.currentTarget && onClose()}
+          >
+            <div
+              ref={panelRef}
+              tabIndex={-1}
+              className="w-[320px] rounded-sm bg-white px-8 py-8"
+            >
+              <h2 id="dialog-title" className="mb-3 text-xl font-bold">
+                {dialog.title ?? "삭제 확인"}
+              </h2>
+              <p id="dialog-message" className="mb-8 text-sm text-gray-600">
+                {dialog.message}
+              </p>
+              <div className="flex justify-end gap-3">
+                {!dialog.alertOnly && (
+                  <Button variant="outline" size="md" onClick={onClose}>
+                    {dialog.cancelText ?? "취소"}
+                  </Button>
+                )}
+                <Button
+                  size="md"
+                  className={dialog.alertOnly ? "" : "bg-error hover:bg-error/90"}
+                  onClick={handleConfirm}
+                >
+                  {dialog.confirmText ?? (dialog.alertOnly ? "확인" : "삭제")}
                 </Button>
-              )}
-              <Button
-                size="md"
-                className={dialog.alertOnly ? "" : "bg-error hover:bg-error/90"}
-                onClick={handleConfirm}
-              >
-                {dialog.confirmText ?? (dialog.alertOnly ? "확인" : "삭제")}
-              </Button>
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body,
+        )}
     </DialogContext.Provider>
   );
 }

--- a/src/components/ModalProvider.tsx
+++ b/src/components/ModalProvider.tsx
@@ -5,8 +5,9 @@ import {
   useState,
   useCallback,
   ReactNode,
-  useEffect,
 } from "react";
+import { createPortal } from "react-dom";
+import { useFocusTrap } from "@/libs/hooks/useFocusTrap";
 
 interface ModalData {
   content: ReactNode;
@@ -27,60 +28,54 @@ interface ModalProviderProps {
 export function ModalProvider({ children }: ModalProviderProps) {
   const [modal, setModal] = useState<ModalData | null>(null);
 
-  const showModal = useCallback((content: ReactNode, title: string) => {
-    setModal({ content, title });
-  }, []);
+  const onClose = useCallback(() => setModal(null), []);
 
-  const onClose = useCallback(() => {
-    setModal(null);
-  }, []);
+  const { panelRef, saveTrigger } = useFocusTrap(modal !== null, onClose);
 
-  useEffect(() => {
-    if (!modal) return;
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKeyDown);
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = "";
-    };
-  }, [onClose, modal]);
+  const showModal = useCallback(
+    (content: ReactNode, title: string) => {
+      saveTrigger();
+      setModal({ content, title });
+    },
+    [saveTrigger],
+  );
 
   return (
     <ModalContext.Provider value={{ showModal, onClose }}>
-      {children}
-      {modal && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="modal-title"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={(e) => e.target === e.currentTarget && onClose()}
-        >
+      <div className="contents" inert={modal !== null}>
+        {children}
+      </div>
+      {modal &&
+        createPortal(
           <div
-            className="scrollbar-ghost relative w-full max-w-[550px] max-h-[85vh] overflow-y-auto rounded-sm bg-white py-8 pr-6 pl-7"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="modal-title"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+            onClick={(e) => e.target === e.currentTarget && onClose()}
           >
-            <div className="mb-6 flex items-center justify-between">
-              <h2 id="modal-title" className="text-xl font-bold">
-                {modal.title}
-              </h2>
-              <button
-                onClick={onClose}
-                aria-label="닫기"
-                className="cursor-pointer text-2xl text-gray-600 hover:text-black"
-              >
-                ✕
-              </button>
+            <div
+              ref={panelRef}
+              tabIndex={-1}
+              className="scrollbar-ghost relative w-full max-w-[550px] max-h-[85vh] overflow-y-auto rounded-sm bg-white py-8 pr-6 pl-7"
+            >
+              <div className="mb-6 flex items-center justify-between">
+                <h2 id="modal-title" className="text-xl font-bold">
+                  {modal.title}
+                </h2>
+                <button
+                  onClick={onClose}
+                  aria-label="닫기"
+                  className="cursor-pointer text-2xl text-gray-600 hover:text-black"
+                >
+                  ✕
+                </button>
+              </div>
+              {modal.content}
             </div>
-
-            {modal.content}
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body,
+        )}
     </ModalContext.Provider>
   );
 }

--- a/src/libs/hooks/useFocusTrap.ts
+++ b/src/libs/hooks/useFocusTrap.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTORS =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+export function useFocusTrap(isOpen: boolean, onClose: () => void) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+
+  const saveTrigger = useCallback(() => {
+    triggerRef.current = document.activeElement;
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const focusable = panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+    (focusable?.[0] ?? panelRef.current)?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const nodes = panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+      if (!nodes?.length) return;
+
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      (triggerRef.current as HTMLElement | null)?.focus();
+    };
+  }, [isOpen, onClose]);
+
+  return { panelRef, saveTrigger };
+}


### PR DESCRIPTION
## Summary

Closes #113

- `h-screen` → `h-dvh` 교체로 모바일 브라우저 주소창 포함 계산 문제 해결
- 태블릿에서 3D 모델 비활성화 및 scrollHeight 101vh 적용 (터치 스크롤 충돌 제거)
- LandingInfo 가운데 정렬을 `inset-0` → `top-[70px] inset-x-0 bottom-0`으로 변경해 헤더 아래 실제 가시 영역 기준 정렬
- FeatureSection 래퍼에 `overflow-x-hidden` 적용 (framer-motion `x: ±100` 초기 애니메이션 오버플로우 방지)
- 랜딩 배경색 `LANDING_BG` 상수로 추출, 매직 스트링 제거
- `pointer-none` 오타 → `pointer-events-none` 수정
- `useScrollProgress`: `prevRef`로 동일 값 no-op `setProgress` 방지
- `LandingInfo`에서 `SCROLL_HEIGHT_VH` 직접 import 제거 → `onScrollToEnd` 콜백 prop으로 분리

## Test plan

- [ ] 데스크탑: 3D 모델 정상 표시 및 스크롤 애니메이션 작동 확인
- [ ] 태블릿 (768px~1279px): 3D 모델 없이 랜딩 정상 표시, 스크롤로 다음 섹션 이동 확인
- [ ] 모바일 (< 768px): 화면 하단/우측 흰 여백 없음 확인, 컨텐츠 가운데 정렬 확인
- [ ] 스크롤 화살표 클릭 시 다음 섹션으로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)