### PR TITLE
feat: 랜딩페이지 스크롤 인디케이터 UX 개선

### DIFF
--- a/src/app/_components/LandingInfo.tsx
+++ b/src/app/_components/LandingInfo.tsx
@@ -55,19 +55,29 @@ export default function LandingInfo({ progress, onScrollToEnd }: LandingInfoProp
           className="mt-16 h-px w-64 origin-center bg-gray-200 md:mt-20 md:w-96"
           variants={lineVariants}
         />
-        <motion.p className="mt-6 text-sm text-gray-500" variants={itemVariants}>
+        <motion.p
+          className="mt-6 text-sm text-gray-500"
+          variants={itemVariants}
+        >
           Codeit. 2026
         </motion.p>
       </motion.div>
 
-      <motion.button
-        className="pointer-events-auto absolute bottom-12 left-1/2 z-10 -translate-x-1/2 cursor-pointer text-7xl text-gray-300 transition-colors hover:text-white md:bottom-14 md:text-8xl"
-        animate={{ y: [0, 10, 0] }}
-        transition={{ duration: 1.5, repeat: Infinity }}
+      <button
+        className="pointer-events-auto absolute bottom-8 left-1/2 z-10 flex -translate-x-1/2 cursor-pointer flex-col items-center text-gray-300 transition-colors hover:text-white md:bottom-10"
         onClick={onScrollToEnd}
       >
-        ⌵
-      </motion.button>
+        <span className="relative top-6 text-[14px] tracking-widest text-white/60 uppercase md:top-7 md:text-base">
+          scroll
+        </span>
+        <motion.span
+          className="text-7xl md:text-8xl"
+          animate={{ y: [0, 10, 0] }}
+          transition={{ duration: 1.5, repeat: Infinity }}
+        >
+          ⌵
+        </motion.span>
+      </button>
     </>
   );
 }
@@ -105,13 +115,11 @@ const charVariants: Variants = {
   hidden: {
     y: "50%",
     opacity: 0,
-
     rotateX: 40,
   },
   visible: {
     y: "0%",
     opacity: 1,
-
     rotateX: 0,
     transition: {
       duration: 1,


### PR DESCRIPTION
## Summary

Closes #115

- 화살표(⌵) 위에 `SCROLL` 텍스트 추가로 스크롤 유도 가시성 향상
- `motion.button` → `button`으로 변경, `motion.span`으로 화살표만 바운스 애니메이션 적용 (텍스트는 고정)
- `text-md` → `text-[14px]` 임의값으로 교체해 `globals.css` 커스텀 유틸리티와 `md:text-base` 반응형 충돌 해결

## Test plan

- [ ] 화살표만 위아래로 바운스되고 SCROLL 텍스트는 고정되어 있는지 확인
- [ ] 모바일/태블릿/데스크탑 모두 SCROLL 텍스트가 정상 표시되는지 확인
- [ ] 버튼 클릭 시 다음 섹션으로 스크롤 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)