### PR TITLE
fix: 필터 변경 시 와인 목록 data undefined 방지

### DIFF
--- a/src/app/_components/LandingInfo.tsx
+++ b/src/app/_components/LandingInfo.tsx
@@ -55,19 +55,29 @@ export default function LandingInfo({ progress, onScrollToEnd }: LandingInfoProp
           className="mt-16 h-px w-64 origin-center bg-gray-200 md:mt-20 md:w-96"
           variants={lineVariants}
         />
-        <motion.p className="mt-6 text-sm text-gray-500" variants={itemVariants}>
+        <motion.p
+          className="mt-6 text-sm text-gray-500"
+          variants={itemVariants}
+        >
           Codeit. 2026
         </motion.p>
       </motion.div>
 
-      <motion.button
-        className="pointer-events-auto absolute bottom-12 left-1/2 z-10 -translate-x-1/2 cursor-pointer text-7xl text-gray-300 transition-colors hover:text-white md:bottom-14 md:text-8xl"
-        animate={{ y: [0, 10, 0] }}
-        transition={{ duration: 1.5, repeat: Infinity }}
+      <button
+        className="pointer-events-auto absolute bottom-8 left-1/2 z-10 flex -translate-x-1/2 cursor-pointer flex-col items-center text-gray-300 transition-colors hover:text-white md:bottom-10"
         onClick={onScrollToEnd}
       >
-        ⌵
-      </motion.button>
+        <span className="relative top-6 text-[14px] tracking-widest text-white/60 uppercase md:top-7 md:text-base">
+          scroll
+        </span>
+        <motion.span
+          className="text-7xl md:text-8xl"
+          animate={{ y: [0, 10, 0] }}
+          transition={{ duration: 1.5, repeat: Infinity }}
+        >
+          ⌵
+        </motion.span>
+      </button>
     </>
   );
 }
@@ -105,13 +115,11 @@ const charVariants: Variants = {
   hidden: {
     y: "50%",
     opacity: 0,
-
     rotateX: 40,
   },
   visible: {
     y: "0%",
     opacity: 1,
-
     rotateX: 0,
     transition: {
       duration: 1,

--- a/src/app/wines/_libs/hooks/useWineList.ts
+++ b/src/app/wines/_libs/hooks/useWineList.ts
@@ -1,5 +1,9 @@
 import { useState, useCallback, useMemo } from "react";
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
 import { fetchWines } from "@/libs/api/wines/getAPIData";
 import { WineFilterValues } from "@/types/wines/types";
 import useDebounce from "./useDebounce";
@@ -16,7 +20,10 @@ export function useWineList() {
   const [filter, setFilter] = useState<WineFilterValues>(INITIAL_FILTER);
   const queryClient = useQueryClient();
 
-  const queryKey = [WINES_QUERY_KEY, { search: debouncedSearch, ...filter }] as const;
+  const queryKey = [
+    WINES_QUERY_KEY,
+    { search: debouncedSearch, ...filter },
+  ] as const;
 
   const { data, isFetching, fetchNextPage, hasNextPage } = useInfiniteQuery({
     queryKey,
@@ -29,6 +36,7 @@ export function useWineList() {
       }),
     initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    placeholderData: keepPreviousData,
   });
 
   const list = useMemo(


### PR DESCRIPTION
## Summary

- 필터/검색어 변경으로 `queryKey`가 바뀔 때, 새 쿼리 로딩 중 `data`가 `undefined`로 떨어지는 현상 수정
- `keepPreviousData` 옵션 추가로 새 fetch 완료 전까지 이전 데이터 유지
- 불필요한 깜빡임(빈 목록 → 새 목록) UX 개선

## Test plan

- [ ] 와인 목록 페이지에서 필터(타입, 가격 등) 변경 시 목록이 비었다가 나타나지 않고 자연스럽게 교체되는지 확인
- [ ] 검색어 입력 시 동일하게 이전 결과가 유지된 채로 새 결과로 교체되는지 확인
- [ ] 무한 스크롤 동작 정상 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)