### PR TITLE
feat: 와인봇 컨텍스트 윈도우 관리 — 카테고리 필터링 추가

### DIFF
--- a/src/app/_components/LandingInfo.tsx
+++ b/src/app/_components/LandingInfo.tsx
@@ -55,19 +55,29 @@ export default function LandingInfo({ progress, onScrollToEnd }: LandingInfoProp
           className="mt-16 h-px w-64 origin-center bg-gray-200 md:mt-20 md:w-96"
           variants={lineVariants}
         />
-        <motion.p className="mt-6 text-sm text-gray-500" variants={itemVariants}>
+        <motion.p
+          className="mt-6 text-sm text-gray-500"
+          variants={itemVariants}
+        >
           Codeit. 2026
         </motion.p>
       </motion.div>
 
-      <motion.button
-        className="pointer-events-auto absolute bottom-12 left-1/2 z-10 -translate-x-1/2 cursor-pointer text-7xl text-gray-300 transition-colors hover:text-white md:bottom-14 md:text-8xl"
-        animate={{ y: [0, 10, 0] }}
-        transition={{ duration: 1.5, repeat: Infinity }}
+      <button
+        className="pointer-events-auto absolute bottom-8 left-1/2 z-10 flex -translate-x-1/2 cursor-pointer flex-col items-center text-gray-300 transition-colors hover:text-white md:bottom-10"
         onClick={onScrollToEnd}
       >
-        ⌵
-      </motion.button>
+        <span className="relative top-6 text-[14px] tracking-widest text-white/60 uppercase md:top-7 md:text-base">
+          scroll
+        </span>
+        <motion.span
+          className="text-7xl md:text-8xl"
+          animate={{ y: [0, 10, 0] }}
+          transition={{ duration: 1.5, repeat: Infinity }}
+        >
+          ⌵
+        </motion.span>
+      </button>
     </>
   );
 }
@@ -105,13 +115,11 @@ const charVariants: Variants = {
   hidden: {
     y: "50%",
     opacity: 0,
-
     rotateX: 40,
   },
   visible: {
     y: "0%",
     opacity: 1,
-
     rotateX: 0,
     transition: {
       duration: 1,

--- a/src/app/wines/_libs/hooks/useWineList.ts
+++ b/src/app/wines/_libs/hooks/useWineList.ts
@@ -1,5 +1,9 @@
 import { useState, useCallback, useMemo } from "react";
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
 import { fetchWines } from "@/libs/api/wines/getAPIData";
 import { WineFilterValues } from "@/types/wines/types";
 import useDebounce from "./useDebounce";
@@ -16,7 +20,10 @@ export function useWineList() {
   const [filter, setFilter] = useState<WineFilterValues>(INITIAL_FILTER);
   const queryClient = useQueryClient();
 
-  const queryKey = [WINES_QUERY_KEY, { search: debouncedSearch, ...filter }] as const;
+  const queryKey = [
+    WINES_QUERY_KEY,
+    { search: debouncedSearch, ...filter },
+  ] as const;
 
   const { data, isFetching, fetchNextPage, hasNextPage } = useInfiniteQuery({
     queryKey,
@@ -29,6 +36,7 @@ export function useWineList() {
       }),
     initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    placeholderData: keepPreviousData,
   });
 
   const list = useMemo(

--- a/src/libs/api/wines/getAPIData.ts
+++ b/src/libs/api/wines/getAPIData.ts
@@ -84,8 +84,20 @@ export async function postWine(wine: PostWineValue) {
   }
 }
 
+function extractWineType(message: string): WineType | undefined {
+  if (/레드|red|까베르네|메를로|피노\s?누아|시라|진판델/i.test(message))
+    return "RED";
+  if (/화이트|white|샤르도네|소비뇽\s?블랑|리슬링|피노\s?그리/i.test(message))
+    return "WHITE";
+  if (/스파클링|sparkling|샴페인|프로세코|카바|버블/i.test(message))
+    return "SPARKLING";
+
+  return undefined;
+}
+
 export async function postWineBotMessage(message: string): Promise<string> {
-  const wineData = await fetchWines({ limit: 10000 });
+  const type = extractWineType(message);
+  const wineData = await fetchWines({ limit: 100, type });
   const wineList = wineData.list.map((w) => ({ id: w.id, name: w.name }));
   const res = await axios.post("/winebot", { wineList, message });
   return res.data.answer;


### PR DESCRIPTION
## Summary

- 사용자 메시지에서 정규식으로 와인 타입(RED / WHITE / SPARKLING)을 추출
- `fetchWines` 호출 시 추출된 타입을 필터로 적용해 관련 카테고리 와인만 컨텍스트에 주입
- `limit` 10000 → 100으로 축소해 토큰 사용량 대폭 절감

## 변경 내용

- `extractWineType(message)` 함수 추가 — 한국어/영어 품종명 키워드 기반 정규식 분류
- 타입 미식별 시 `undefined` 반환 → 전체 목록에서 100개 샘플링

## Test plan

- [ ] "레드 와인 추천해줘" → RED 타입 필터 적용 여부 확인
- [ ] "샴페인 마시고 싶어" → SPARKLING 필터 적용 여부 확인
- [ ] "와인 추천해줘" (타입 없음) → 전체에서 100개 샘플링 확인
- [ ] 추천 결과가 정상적으로 반환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)