### PR TITLE
feat: 로그인 후 원래 페이지로 리다이렉트 (#120)

### DIFF
--- a/src/app/(auth)/_components/LoginForm.tsx
+++ b/src/app/(auth)/_components/LoginForm.tsx
@@ -2,7 +2,7 @@
 
 import { FormikHelpers } from "formik";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import type { FocusTarget } from "./Character";
 import Image from "next/image";
 import { LoginFormValues, loginSchema } from "../_libs/authSchema";
@@ -51,10 +51,17 @@ export default function LoginForm({
 }: LoginFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { setUser } = useUser();
   const { showToast } = useToast();
 
+  const getRedirectPath = () => searchParams.get("redirect") || "/";
+
   const handleKakaoLogin = () => {
+    const redirect = getRedirectPath();
+    if (redirect !== "/") {
+      localStorage.setItem("kakaoRedirect", redirect);
+    }
     window.location.href = process.env.NEXT_PUBLIC_KAKAO_AUTH_URL!;
   };
 
@@ -67,7 +74,7 @@ export default function LoginForm({
       });
       setUser(data.user);
       showToast("로그인에 성공했습니다", "success");
-      router.replace("/");
+      router.replace(getRedirectPath());
     } catch (e: any) {
       const errorMessage = e.response?.data?.message || "로그인에 실패했습니다";
       showToast(errorMessage, "error");
@@ -89,7 +96,7 @@ export default function LoginForm({
       const data = await postLoginData(loginData);
       setUser(data.user);
       showToast("로그인에 성공했습니다", "success");
-      router.replace("/");
+      router.replace(getRedirectPath());
     } catch (e: any) {
       const errorMessage = e.response?.data?.message || "로그인에 실패했습니다";
       console.log(errorMessage);

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import { Suspense } from "react";
 import AuthLayout from "../_components/AuthLayout";
 import LoginForm from "../_components/LoginForm";
 
 export default function LoginPage() {
   return (
     <AuthLayout>
-      {(props) => <LoginForm {...props} />}
+      {(props) => (
+        <Suspense>
+          <LoginForm {...props} />
+        </Suspense>
+      )}
     </AuthLayout>
   );
 }

--- a/src/app/oauth/kakao/_components/KakaoCallback.tsx
+++ b/src/app/oauth/kakao/_components/KakaoCallback.tsx
@@ -40,7 +40,9 @@ export default function KakaoCallback() {
         });
         setUser(data.user);
         showToast("카카오 로그인에 성공했습니다!", "success");
-        router.replace("/");
+        const redirectPath = localStorage.getItem("kakaoRedirect") || "/";
+        localStorage.removeItem("kakaoRedirect");
+        router.replace(redirectPath);
       } catch (e: any) {
         const errorMessage =
           e.response?.data?.message || "카카오 로그인에 실패했습니다.";

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,14 +21,17 @@ export function middleware(request: NextRequest) {
   );
 
   if (isProtectedRoute && !hasValidSession) {
-    return NextResponse.redirect(new URL("/login", request.url));
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("redirect", pathname);
+    return NextResponse.redirect(loginUrl);
   }
 
   //auth페이지 접근 방지(이미 인증시)
   const isAuthRoute = AUTH_ROUTES.some((route) => pathname === route);
 
   if (isAuthRoute && hasValidSession) {
-    return NextResponse.redirect(new URL("/", request.url));
+    const redirectTo = request.nextUrl.searchParams.get("redirect") || "/";
+    return NextResponse.redirect(new URL(redirectTo, request.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
closes #120

## Summary

- 인증이 필요한 페이지 접근 시 로그인 완료 후 원래 가려던 페이지로 자동 이동
- 이메일 로그인 / 게스트 로그인 / 카카오 로그인 모두 처리

## 변경 내용

| 파일 | 변경 내용 |
|------|----------|
| `middleware.ts` | 보호 경로 접근 시 `/login?redirect=<경로>`로 리다이렉트. 이미 로그인된 상태로 `/login` 접근 시 `redirect` 파라미터 경로로 이동 |
| `LoginForm.tsx` | 로그인 성공 후 `redirect` 쿼리 파라미터 경로로 이동. 카카오 로그인 전 `redirect` 경로를 `localStorage`에 저장 |
| `KakaoCallback.tsx` | OAuth 완료 후 `localStorage`의 저장된 경로로 이동 후 항목 삭제 |

## Test plan

- [ ] `/myprofile` 접근 시 `/login?redirect=/myprofile`로 이동하는지 확인
- [ ] 이메일 로그인 성공 후 `/myprofile`로 이동하는지 확인
- [ ] 게스트 로그인 성공 후 원래 경로로 이동하는지 확인
- [ ] 카카오 로그인 성공 후 원래 경로로 이동하는지 확인
- [ ] redirect 파라미터 없이 로그인 시 `/`(홈)으로 이동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)