### PR TITLE
feat: 로그인 기본 리다이렉트 경로를 /에서 /wines로 변경

### DIFF
--- a/src/app/(auth)/_components/LoginForm.tsx
+++ b/src/app/(auth)/_components/LoginForm.tsx
@@ -55,11 +55,11 @@ export default function LoginForm({
   const { setUser } = useUser();
   const { showToast } = useToast();
 
-  const getRedirectPath = () => searchParams.get("redirect") || "/";
+  const getRedirectPath = () => searchParams.get("redirect") || "/wines";
 
   const handleKakaoLogin = () => {
-    const redirect = getRedirectPath();
-    if (redirect !== "/") {
+    const redirect = searchParams.get("redirect");
+    if (redirect) {
       localStorage.setItem("kakaoRedirect", redirect);
     }
     window.location.href = process.env.NEXT_PUBLIC_KAKAO_AUTH_URL!;

--- a/src/app/oauth/kakao/_components/KakaoCallback.tsx
+++ b/src/app/oauth/kakao/_components/KakaoCallback.tsx
@@ -40,7 +40,7 @@ export default function KakaoCallback() {
         });
         setUser(data.user);
         showToast("카카오 로그인에 성공했습니다!", "success");
-        const redirectPath = localStorage.getItem("kakaoRedirect") || "/";
+        const redirectPath = localStorage.getItem("kakaoRedirect") || "/wines";
         localStorage.removeItem("kakaoRedirect");
         router.replace(redirectPath);
         router.refresh();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,7 +30,7 @@ export function middleware(request: NextRequest) {
   const isAuthRoute = AUTH_ROUTES.some((route) => pathname === route);
 
   if (isAuthRoute && hasValidSession) {
-    const redirectTo = request.nextUrl.searchParams.get("redirect") || "/";
+    const redirectTo = request.nextUrl.searchParams.get("redirect") || "/wines";
     return NextResponse.redirect(new URL(redirectTo, request.url));
   }
 


### PR DESCRIPTION
## Summary

`redirect` 쿼리 파라미터가 없을 때 로그인 후 이동하는 기본 경로를 `/`(랜딩)에서 `/wines`로 변경.

## Changes

- [src/app/(auth)/_components/LoginForm.tsx](src/app/(auth)/_components/LoginForm.tsx): `getRedirectPath` 기본값 변경. 카카오 로그인 전 `localStorage.kakaoRedirect` 저장 조건을 `redirect !== "/"`에서 `redirect가 존재할 때`로 단순화
- [src/app/oauth/kakao/_components/KakaoCallback.tsx](src/app/oauth/kakao/_components/KakaoCallback.tsx): 카카오 콜백 기본 이동 경로 변경
- [src/middleware.ts](src/middleware.ts): 이미 인증된 사용자가 `/login`·`/signup` 접근 시 fallback 경로 변경

## Test plan

- [ ] 로그아웃 상태에서 `/login` 직접 접속 후 이메일 로그인 → `/wines` 이동
- [ ] 게스트 로그인 → `/wines`
- [ ] 카카오 로그인 → `/wines`
- [ ] 로그아웃 상태에서 `/wines/123` 접속 → 로그인 → 원래 `/wines/123`로 이동 (redirect 파라미터 정상 동작)
- [ ] 로그인된 상태에서 `/login` 접근 → `/wines`로 리다이렉트
