### PR TITLE
perf: 랜딩 3D GLB 모델 선제 다운로드로 초기 렌더 지연 단축

### DIFF
--- a/src/app/_components/RenderModel.tsx
+++ b/src/app/_components/RenderModel.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { Canvas } from '@react-three/fiber';
+import { useGLTF } from '@react-three/drei';
 import { Suspense } from 'react';
 import LightObject from './LightObject';
 import { WineModel } from './WineModel';
 
 import { DeviceType } from '@/libs/zustand';
+
+useGLTF.preload('/main/opti_wine_objects.glb');
 
 interface RenderModelProps {
   deviceType: DeviceType;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,13 @@ import FeatureSection from './_components/FeatureSection';
 export default function Home() {
   return (
     <div>
+      <link
+        rel="preload"
+        href="/main/opti_wine_objects.glb"
+        as="fetch"
+        type="model/gltf-binary"
+        crossOrigin="anonymous"
+      />
       <LandingSection>
         <FeatureSection />
       </LandingSection>


### PR DESCRIPTION
## 요약

랜딩 페이지의 3D 와인 모델(`/main/opti_wine_objects.glb`)이 `<Canvas>` 마운트 이후에야 다운로드되는 문제를 해결합니다. HTML 파싱 단계에서 GLB를 병렬로 선제 다운로드하여 Canvas 마운트 시 네트워크 대기 시간을 제거합니다.

Closes #128

## 변경 내용

### `src/app/page.tsx`
랜딩 페이지(`/`)에만 preload 힌트를 주입합니다. Next.js App Router + React 19가 `<link>`를 자동으로 `<head>`로 승격시켜, 브라우저 preload scanner가 JS 실행 이전에 GLB 다운로드를 시작합니다.

```tsx
<link
  rel="preload"
  href="/main/opti_wine_objects.glb"
  as="fetch"
  type="model/gltf-binary"
  crossOrigin="anonymous"
/>
```

루트 레이아웃이 아닌 페이지 단위에 두어 `/wines`, `/myprofile` 등 타 경로에서 불필요한 다운로드가 발생하지 않도록 했습니다.

### `src/app/_components/RenderModel.tsx`
모듈 최상단에서 `useGLTF.preload()`를 호출해, 클라이언트 JS 실행 직후 drei의 캐시가 preload된 GLB를 재사용하도록 합니다.

```ts
useGLTF.preload('/main/opti_wine_objects.glb');
```

## 다운로드 타이밍 비교

### 변경 전
```
HTML → JS 번들 → 하이드레이션 → <Canvas> 마운트 → useGLTF() → [GLB 다운로드 시작]
```

### 변경 후
```
HTML → [GLB 다운로드 시작] (병렬)
       ↓
       JS 번들 → 하이드레이션 → <Canvas> 마운트 → useGLTF() → [캐시 hit → 즉시 렌더]
```

## 구현 시 주의점

- **`as="fetch"` + `crossOrigin="anonymous"` 쌍**: `useGLTF` 내부 fetch는 same-origin anonymous 모드로 동작합니다. preload의 CORS 모드가 일치하지 않으면 브라우저가 preload 캐시를 재사용하지 않아 **두 번 다운로드**됩니다.
- **`type="model/gltf-binary"`**: 선택 속성이지만 브라우저가 MIME 기반 우선순위를 결정할 때 힌트로 활용합니다.

## Test plan

- [ ] Chrome DevTools **Network 탭**에서 `opti_wine_objects.glb`의 Initiator가 `(preload)`로 표시되고 HTML 직후 병렬로 다운로드되는지 확인
- [ ] 콘솔에 `was preloaded using link preload but not used` 경고가 **없는지** 확인 (있으면 `as`/`crossOrigin` 불일치)
- [ ] 데스크톱 환경에서 랜딩 페이지 스크롤 → 카메라 이동 → 페이드아웃 → `/wines` 버튼 노출 등 기존 랜딩 인터랙션 정상 동작 확인
- [ ] 모바일/태블릿에서 3D Canvas가 렌더되지 않으면서 레이아웃이 깨지지 않는지 확인
- [ ] `/wines`, `/myprofile` 등 타 경로에서 GLB가 **다운로드되지 않는지** Network 탭으로 확인
