### PR TITLE
refactor: 공통 Overlay/useOverlay 프리미티브 추출 및 scroll lock 버그 수정

### DIFF
--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -2,115 +2,132 @@
 import {
   createContext,
   useContext,
-  useState,
   useCallback,
+  useMemo,
   ReactNode,
 } from "react";
-import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/Button";
-import { useFocusTrap } from "@/libs/hooks/useFocusTrap";
+import { Overlay } from "@/components/overlay/Overlay";
+import { useOverlay } from "@/libs/hooks/useOverlay";
 
-interface ConfirmData {
-  message: string;
+interface ConfirmOptions {
   title?: string;
   confirmText?: string;
   cancelText?: string;
-  onConfirm: () => void;
-  alertOnly?: boolean;
 }
+
+interface AlertOptions {
+  title?: string;
+  confirmText?: string;
+}
+
+type DialogData =
+  | ({
+      kind: "confirm";
+      message: string;
+      onConfirm: () => void;
+    } & ConfirmOptions)
+  | ({
+      kind: "alert";
+      message: string;
+    } & AlertOptions);
 
 interface DialogContextValue {
   showConfirm: (
     message: string,
     onConfirm: () => void,
-    options?: { title?: string; confirmText?: string; cancelText?: string },
+    options?: ConfirmOptions,
   ) => void;
-  showAlert: (
-    message: string,
-    options?: { title?: string; confirmText?: string },
-  ) => void;
+  showAlert: (message: string, options?: AlertOptions) => void;
 }
 
 const DialogContext = createContext<DialogContextValue | null>(null);
 
-export function DialogProvider({ children }: { children: ReactNode }) {
-  const [dialog, setDialog] = useState<ConfirmData | null>(null);
+interface DialogProviderProps {
+  children: ReactNode;
+}
 
-  const onClose = useCallback(() => setDialog(null), []);
-
-  const { panelRef, saveTrigger } = useFocusTrap(dialog !== null, onClose);
+export function DialogProvider({ children }: DialogProviderProps): ReactNode {
+  const { state: dialog, open, close, panelRef } = useOverlay<DialogData>();
 
   const showConfirm = useCallback(
-    (
-      message: string,
-      onConfirm: () => void,
-      options?: { title?: string; confirmText?: string; cancelText?: string },
-    ) => {
-      saveTrigger();
-      setDialog({ message, onConfirm, ...options });
+    (message: string, onConfirm: () => void, options?: ConfirmOptions) => {
+      open({ kind: "confirm", message, onConfirm, ...options });
     },
-    [saveTrigger],
+    [open],
   );
 
   const showAlert = useCallback(
-    (message: string, options?: { title?: string; confirmText?: string }) => {
-      saveTrigger();
-      setDialog({ message, onConfirm: () => {}, alertOnly: true, ...options });
+    (message: string, options?: AlertOptions) => {
+      open({ kind: "alert", message, ...options });
     },
-    [saveTrigger],
+    [open],
   );
 
   const handleConfirm = useCallback(() => {
-    const cb = dialog?.onConfirm;
-    onClose();
+    const cb = dialog?.kind === "confirm" ? dialog.onConfirm : undefined;
+    close();
     cb?.();
-  }, [dialog, onClose]);
+  }, [dialog, close]);
+
+  const value = useMemo<DialogContextValue>(
+    () => ({ showConfirm, showAlert }),
+    [showConfirm, showAlert],
+  );
 
   return (
-    <DialogContext.Provider value={{ showConfirm, showAlert }}>
+    <DialogContext.Provider value={value}>
       <div className="contents" inert={dialog !== null}>
         {children}
       </div>
-      {dialog &&
-        createPortal(
-          <div
-            role="alertdialog"
-            aria-modal="true"
-            aria-labelledby="dialog-title"
-            aria-describedby="dialog-message"
-            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
-            onClick={(e) => e.target === e.currentTarget && onClose()}
-          >
-            <div
-              ref={panelRef}
-              tabIndex={-1}
-              className="w-[320px] rounded-sm bg-white px-8 py-8"
-            >
-              <h2 id="dialog-title" className="mb-3 text-xl font-bold">
-                {dialog.title ?? "삭제 확인"}
-              </h2>
-              <p id="dialog-message" className="mb-8 text-sm text-gray-600">
-                {dialog.message}
-              </p>
-              <div className="flex justify-end gap-3">
-                {!dialog.alertOnly && (
-                  <Button variant="outline" size="md" onClick={onClose}>
-                    {dialog.cancelText ?? "취소"}
-                  </Button>
-                )}
-                <Button
-                  size="md"
-                  className={dialog.alertOnly ? "" : "bg-error hover:bg-error/90"}
-                  onClick={handleConfirm}
-                >
-                  {dialog.confirmText ?? (dialog.alertOnly ? "확인" : "삭제")}
-                </Button>
-              </div>
-            </div>
-          </div>,
-          document.body,
-        )}
+      {dialog && (
+        <Overlay
+          role="alertdialog"
+          labelledBy="dialog-title"
+          describedBy="dialog-message"
+          panelRef={panelRef}
+          panelClassName="w-[320px] rounded-sm bg-white px-8 py-8"
+          zIndexClass="z-[60]"
+          onClose={close}
+        >
+          <DialogBody dialog={dialog} onCancel={close} onConfirm={handleConfirm} />
+        </Overlay>
+      )}
     </DialogContext.Provider>
+  );
+}
+
+interface DialogBodyProps {
+  dialog: DialogData;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+function DialogBody({ dialog, onCancel, onConfirm }: DialogBodyProps): ReactNode {
+  const isConfirm = dialog.kind === "confirm";
+  const defaultTitle = isConfirm ? "삭제 확인" : "알림";
+  const defaultConfirmText = isConfirm ? "삭제" : "확인";
+  const confirmClassName = isConfirm ? "bg-error hover:bg-error/90" : "";
+
+  return (
+    <>
+      <h2 id="dialog-title" className="mb-3 text-xl font-bold">
+        {dialog.title ?? defaultTitle}
+      </h2>
+      <p id="dialog-message" className="mb-8 text-sm text-gray-600">
+        {dialog.message}
+      </p>
+      <div className="flex justify-end gap-3">
+        {isConfirm && (
+          <Button variant="outline" size="md" onClick={onCancel}>
+            {dialog.cancelText ?? "취소"}
+          </Button>
+        )}
+        <Button size="md" className={confirmClassName} onClick={onConfirm}>
+          {dialog.confirmText ?? defaultConfirmText}
+        </Button>
+      </div>
+    </>
   );
 }
 

--- a/src/components/ModalProvider.tsx
+++ b/src/components/ModalProvider.tsx
@@ -2,12 +2,12 @@
 import {
   createContext,
   useContext,
-  useState,
   useCallback,
+  useMemo,
   ReactNode,
 } from "react";
-import { createPortal } from "react-dom";
-import { useFocusTrap } from "@/libs/hooks/useFocusTrap";
+import { Overlay } from "@/components/overlay/Overlay";
+import { useOverlay } from "@/libs/hooks/useOverlay";
 
 interface ModalData {
   content: ReactNode;
@@ -25,57 +25,47 @@ interface ModalProviderProps {
   children: ReactNode;
 }
 
-export function ModalProvider({ children }: ModalProviderProps) {
-  const [modal, setModal] = useState<ModalData | null>(null);
-
-  const onClose = useCallback(() => setModal(null), []);
-
-  const { panelRef, saveTrigger } = useFocusTrap(modal !== null, onClose);
+export function ModalProvider({ children }: ModalProviderProps): ReactNode {
+  const { state: modal, open, close, panelRef } = useOverlay<ModalData>();
 
   const showModal = useCallback(
-    (content: ReactNode, title: string) => {
-      saveTrigger();
-      setModal({ content, title });
-    },
-    [saveTrigger],
+    (content: ReactNode, title: string) => open({ content, title }),
+    [open],
+  );
+
+  const value = useMemo<ModalContextValue>(
+    () => ({ showModal, onClose: close }),
+    [showModal, close],
   );
 
   return (
-    <ModalContext.Provider value={{ showModal, onClose }}>
+    <ModalContext.Provider value={value}>
       <div className="contents" inert={modal !== null}>
         {children}
       </div>
-      {modal &&
-        createPortal(
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="modal-title"
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-            onClick={(e) => e.target === e.currentTarget && onClose()}
-          >
-            <div
-              ref={panelRef}
-              tabIndex={-1}
-              className="scrollbar-ghost relative w-full max-w-[550px] max-h-[85vh] overflow-y-auto rounded-sm bg-white py-8 pr-6 pl-7"
+      {modal && (
+        <Overlay
+          role="dialog"
+          labelledBy="modal-title"
+          panelRef={panelRef}
+          panelClassName="scrollbar-ghost relative w-full max-w-[550px] max-h-[85vh] overflow-y-auto rounded-sm bg-white py-8 pr-6 pl-7"
+          onClose={close}
+        >
+          <div className="mb-6 flex items-center justify-between">
+            <h2 id="modal-title" className="text-xl font-bold">
+              {modal.title}
+            </h2>
+            <button
+              onClick={close}
+              aria-label="닫기"
+              className="cursor-pointer text-2xl text-gray-600 hover:text-black"
             >
-              <div className="mb-6 flex items-center justify-between">
-                <h2 id="modal-title" className="text-xl font-bold">
-                  {modal.title}
-                </h2>
-                <button
-                  onClick={onClose}
-                  aria-label="닫기"
-                  className="cursor-pointer text-2xl text-gray-600 hover:text-black"
-                >
-                  ✕
-                </button>
-              </div>
-              {modal.content}
-            </div>
-          </div>,
-          document.body,
-        )}
+              ✕
+            </button>
+          </div>
+          {modal.content}
+        </Overlay>
+      )}
     </ModalContext.Provider>
   );
 }

--- a/src/components/overlay/Overlay.tsx
+++ b/src/components/overlay/Overlay.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { ReactNode, RefObject, MouseEvent } from "react";
+import { createPortal } from "react-dom";
+
+type OverlayRole = "dialog" | "alertdialog";
+
+interface OverlayProps {
+  role: OverlayRole;
+  labelledBy: string;
+  describedBy?: string;
+  panelRef: RefObject<HTMLDivElement | null>;
+  panelClassName: string;
+  zIndexClass?: string;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function Overlay({
+  role,
+  labelledBy,
+  describedBy,
+  panelRef,
+  panelClassName,
+  zIndexClass = "z-50",
+  onClose,
+  children,
+}: OverlayProps): ReactNode {
+  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>): void => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return createPortal(
+    <div
+      role={role}
+      aria-modal="true"
+      aria-labelledby={labelledBy}
+      aria-describedby={describedBy}
+      className={`fixed inset-0 ${zIndexClass} flex items-center justify-center bg-black/50`}
+      onClick={handleBackdropClick}
+    >
+      <div ref={panelRef} tabIndex={-1} className={panelClassName}>
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/libs/hooks/useFocusTrap.ts
+++ b/src/libs/hooks/useFocusTrap.ts
@@ -1,9 +1,32 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, RefObject } from "react";
 
 const FOCUSABLE_SELECTORS =
   'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
-export function useFocusTrap(isOpen: boolean, onClose: () => void) {
+let scrollLockCount = 0;
+let savedBodyOverflow = "";
+
+function lockBodyScroll(): void {
+  if (scrollLockCount === 0) {
+    savedBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+  scrollLockCount += 1;
+}
+
+function unlockBodyScroll(): void {
+  scrollLockCount -= 1;
+  if (scrollLockCount === 0) {
+    document.body.style.overflow = savedBodyOverflow;
+  }
+}
+
+interface UseFocusTrapResult {
+  panelRef: RefObject<HTMLDivElement | null>;
+  saveTrigger: () => void;
+}
+
+export function useFocusTrap(isOpen: boolean, onClose: () => void): UseFocusTrapResult {
   const panelRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<Element | null>(null);
 
@@ -14,8 +37,7 @@ export function useFocusTrap(isOpen: boolean, onClose: () => void) {
   useEffect(() => {
     if (!isOpen) return;
 
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
+    lockBodyScroll();
 
     const focusable = panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
     (focusable?.[0] ?? panelRef.current)?.focus();
@@ -45,7 +67,7 @@ export function useFocusTrap(isOpen: boolean, onClose: () => void) {
     document.addEventListener("keydown", handleKeyDown);
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = previousOverflow;
+      unlockBodyScroll();
       (triggerRef.current as HTMLElement | null)?.focus();
     };
   }, [isOpen, onClose]);

--- a/src/libs/hooks/useOverlay.ts
+++ b/src/libs/hooks/useOverlay.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState, RefObject } from "react";
+import { useFocusTrap } from "./useFocusTrap";
+
+interface UseOverlayResult<T> {
+  state: T | null;
+  open: (value: T) => void;
+  close: () => void;
+  panelRef: RefObject<HTMLDivElement | null>;
+}
+
+export function useOverlay<T>(): UseOverlayResult<T> {
+  const [state, setState] = useState<T | null>(null);
+
+  const close = useCallback(() => setState(null), []);
+
+  const { panelRef, saveTrigger } = useFocusTrap(state !== null, close);
+
+  const open = useCallback(
+    (value: T) => {
+      saveTrigger();
+      setState(value);
+    },
+    [saveTrigger],
+  );
+
+  return { state, open, close, panelRef };
+}


### PR DESCRIPTION
Closes #132

## 요약

`ModalProvider`와 `DialogProvider`의 구조적 중복(포털, 백드롭, 바깥클릭 닫기, focus trap 배선, `inert` 래퍼, state+saveTrigger 패턴)을 공통 프리미티브로 추출하고, 함께 발견된 버그·품질 이슈를 정리했습니다.

## 변경 내역

### 신규

- `src/components/overlay/Overlay.tsx` — 포털 + 백드롭 + 패널 + 바깥클릭 닫기 + ARIA 속성을 담당하는 공통 컴포넌트.
- `src/libs/hooks/useOverlay.ts` — `useState<T|null>` + `useFocusTrap` + `saveTrigger` 패턴을 캡슐화한 훅.

### 수정

- **`useFocusTrap`**: `document.body.style.overflow`를 모듈 레벨 카운터(`scrollLockCount`, `savedBodyOverflow`)로 관리하도록 교체. 기존엔 각 훅 인스턴스가 개별적으로 `previousOverflow`를 캡처해서, Modal → Dialog 순으로 열고 **Modal이 먼저 닫힐 때** Dialog가 아직 떠 있는데도 스크롤이 풀리는 버그가 있었음. 이제 마지막 오버레이가 닫힐 때만 원래 값으로 복원.
  - 명시적 반환 타입 `UseFocusTrapResult` 추가.
- **`ModalProvider`**:
  - `useOverlay<ModalData>()`로 상태·focus trap 처리를 위임.
  - 포털/백드롭/패널 마크업을 `<Overlay>`로 교체.
  - `value`를 `useMemo`로 감싸 consumer 리렌더 방지.
- **`DialogProvider`**:
  - 내부 상태를 `kind: "confirm" | "alert"` discriminated union으로 변경. `alertOnly` 불리언 플래그와 `showAlert`가 넣던 더미 `onConfirm: () => {}` 제거.
  - 렌더 로직을 `DialogBody` 서브컴포넌트로 분리하고 기본 title/confirmText/배경 클래스를 `isConfirm` 변수로 한 번만 계산 → 중첩 삼항 제거.
  - `value`를 `useMemo`로 감쌈.
  - **외부 API(`showConfirm` / `showAlert` 시그니처)는 변경되지 않았으므로 호출부 수정은 없습니다.**

## 의도적으로 범위에서 제외

- `showConfirm` / `showAlert`의 옵션 객체 구조 개편 — 모든 호출부를 건드릴 필요가 있어 별도 PR 대상.
- `useFocusTrap`의 Tab 키 핸들러 내 `querySelectorAll` 캐싱 — Tab은 핫패스가 아니고 DOM 변동 대응이 복잡해짐.
- 기본 라벨(`"삭제 확인"`, `"삭제"`, `"확인"`, `"취소"`) 상수화/i18n 분리.

## 테스트 플랜

- [ ] 마이프로필에서 리뷰 수정 모달(ModalProvider) 열기/닫기/ESC/바깥 클릭/Tab 순환 동작.
- [ ] 와인 등록/수정 모달 열기/닫기.
- [ ] 삭제 확인 다이얼로그(`showConfirm`) — 취소 버튼 노출, 확인 시 콜백 실행, 취소 시 콜백 미실행.
- [ ] 알림 다이얼로그(`showAlert`) — 취소 버튼 미노출, 기본 타이틀 "알림", 기본 버튼 "확인".
- [ ] **모달 → 다이얼로그 순으로 연 뒤 모달을 먼저 닫아도** body 스크롤이 다이얼로그 닫힐 때까지 잠겨 있는지 확인 (이번 PR의 핵심 버그 수정 검증).
- [ ] trigger 요소로 포커스 복원.
